### PR TITLE
Added SHUTDOWN support for MCP9808

### DIFF
--- a/Adafruit_MCP9808.cpp
+++ b/Adafruit_MCP9808.cpp
@@ -55,7 +55,7 @@ boolean Adafruit_MCP9808::begin(uint8_t addr) {
 
   return true;
 }
- 
+
 /**************************************************************************/
 /*! 
     @brief  Reads the 16-bit temperature register and returns the Centigrade
@@ -72,6 +72,37 @@ float Adafruit_MCP9808::readTempC( void )
   if (t & 0x1000) temp -= 256;
 
   return temp;
+}
+
+/**************************************************************************/
+/*! 
+    @brief  Sends the MCP9808 into SHUTDOWN mode, if possible
+
+*/
+/**************************************************************************/
+boolean Adafruit_MCP9808::powerDown( void )
+{
+  uint16_t t = read16(MCP9808_REG_CONFIG);
+  if (t & MCP9808_REG_CONFIG_CRITLOCKED == MCP9808_REG_CONFIG_CRITLOCKED ||
+      t & MCP9808_REG_CONFIG_WINLOCKED == MCP9808_REG_CONFIG_WINLOCKED) {
+      	return false;
+      }
+  t |= MCP9808_REG_CONFIG_SHUTDOWN;
+  write16(MCP9808_REG_CONFIG, t);
+  return true;
+}
+
+/**************************************************************************/
+/*! 
+    @brief  Brings the MCP9808 out of SHUTDOWN mode
+
+*/
+/**************************************************************************/
+void Adafruit_MCP9808::powerUp( void )
+{
+  uint16_t t = read16(MCP9808_REG_CONFIG);
+  t &= ~MCP9808_REG_CONFIG_SHUTDOWN;
+  write16(MCP9808_REG_CONFIG, t);
 }
 
 /**************************************************************************/

--- a/Adafruit_MCP9808.h
+++ b/Adafruit_MCP9808.h
@@ -56,6 +56,8 @@ class Adafruit_MCP9808 {
   boolean begin(uint8_t a = MCP9808_I2CADDR_DEFAULT);  
   float readTempF( void );
   float readTempC( void );
+  void powerDown( void );
+  void powerUp( void );
 
   void write16(uint8_t reg, uint16_t val);
   uint16_t read16(uint8_t reg);

--- a/Adafruit_MCP9808.h
+++ b/Adafruit_MCP9808.h
@@ -56,7 +56,7 @@ class Adafruit_MCP9808 {
   boolean begin(uint8_t a = MCP9808_I2CADDR_DEFAULT);  
   float readTempF( void );
   float readTempC( void );
-  void powerDown( void );
+  boolean powerDown( void );
   void powerUp( void );
 
   void write16(uint8_t reg, uint16_t val);


### PR DESCRIPTION
Defines and implements two functions, powerDown and powerUp, allowing the controller to send the MCP9808 into SHUTDOWN mode. Will not allow SHUTDOWN mode if any of the LOCK bits are set (per datasheet).
