### PR TITLE
added to the api awake/shutdown

### DIFF
--- a/Adafruit_MCP9808.cpp
+++ b/Adafruit_MCP9808.cpp
@@ -74,34 +74,21 @@ float Adafruit_MCP9808::readTempC( void )
   return temp;
 }
 
-
-
-//*************************************************************************
-// Set Sensor to Shutdown-State or wake up (Conf_Register BIT8)
-// 1= shutdown / 0= wake up
-//*************************************************************************
-
-int Adafruit_MCP9808::shutdown_wake( uint8_t sw_ID )
+void Adafruit_MCP9808::shutdown()
 {
     uint16_t conf_shutdown ;
     uint16_t conf_register = read16(MCP9808_REG_CONFIG);
-    if (sw_ID == 1)
-    {
-       conf_shutdown = conf_register | MCP9808_REG_CONFIG_SHUTDOWN ;
-       write16(MCP9808_REG_CONFIG, conf_shutdown);
-    }
-    if (sw_ID == 0)
-    {
-       conf_shutdown = conf_register ^ MCP9808_REG_CONFIG_SHUTDOWN ;
-       write16(MCP9808_REG_CONFIG, conf_shutdown);
-    }
-
-
-    return 0;
+    conf_shutdown = conf_register ^ MCP9808_REG_CONFIG_SHUTDOWN ;
+    write16(MCP9808_REG_CONFIG, conf_shutdown);
 }
 
-
-
+void Adafruit_MCP9808::awake()
+{
+    uint16_t conf_shutdown ;
+    uint16_t conf_register = read16(MCP9808_REG_CONFIG);
+    conf_shutdown = conf_register | MCP9808_REG_CONFIG_SHUTDOWN ;
+    write16(MCP9808_REG_CONFIG, conf_shutdown);
+}
 
 /**************************************************************************/
 /*! 

--- a/Adafruit_MCP9808.h
+++ b/Adafruit_MCP9808.h
@@ -56,7 +56,16 @@ class Adafruit_MCP9808 {
   boolean begin(uint8_t a = MCP9808_I2CADDR_DEFAULT);  
   float readTempF( void );
   float readTempC( void );
-  int shutdown_wake( uint8_t sw_ID );
+  void shutdown();
+  void awake();
+  int shutdown_wake( uint8_t sw_ID ) {
+    if (sw_ID == 0) {
+      shutdown();
+    } else {
+      awake();
+    }
+    return 0;
+  }
 
   void write16(uint8_t reg, uint16_t val);
   uint16_t read16(uint8_t reg);


### PR DESCRIPTION
There is no different in size or speed to two seperated function which
are named like what they do.
So i added them and left the api to shutdown_wake like it was. But
i would recomment to remove shutdown_wake in the next release.

thx meno
