### PR TITLE
Tweaks to fix some issues with the device library

### DIFF
--- a/Adafruit_MCP9808.cpp
+++ b/Adafruit_MCP9808.cpp
@@ -108,7 +108,7 @@ int Adafruit_MCP9808::shutdown_wake( uint8_t sw_ID )
 /**************************************************************************/
 
 void Adafruit_MCP9808::write16(uint8_t reg, uint16_t value) {
-	Wire.beginTransmission(_i2caddr);
+    Wire.beginTransmission(_i2caddr);
     Wire.write((uint8_t)reg);
     Wire.write(value >> 8);
     Wire.write(value & 0xFF);

--- a/Adafruit_MCP9808.cpp
+++ b/Adafruit_MCP9808.cpp
@@ -100,18 +100,6 @@ int Adafruit_MCP9808::shutdown_wake( uint8_t sw_ID )
     return 0;
 }
 
-void Adafruit_MCP9808::regdump( )
-{
-	int  i;
-	uint16_t reg;
-	char data[6];
-	for (i=1;i<=7;++i) {
-		reg = read16(i);
-		sprintf(data, "%04x:", reg);
-		Serial.print(data);
-	}
-	Serial.println("");
-}
 
 /**************************************************************************/
 /*! 

--- a/Adafruit_MCP9808.cpp
+++ b/Adafruit_MCP9808.cpp
@@ -92,7 +92,7 @@ int Adafruit_MCP9808::shutdown_wake( uint8_t sw_ID )
     }
     if (sw_ID == 0)
     {
-       conf_shutdown = conf_register ^ MCP9808_REG_CONFIG_SHUTDOWN ;
+       conf_shutdown = conf_register & (~MCP9808_REG_CONFIG_SHUTDOWN) ;
        write16(MCP9808_REG_CONFIG, conf_shutdown);
     }
 
@@ -100,8 +100,18 @@ int Adafruit_MCP9808::shutdown_wake( uint8_t sw_ID )
     return 0;
 }
 
-
-
+void Adafruit_MCP9808::regdump( )
+{
+	int  i;
+	uint16_t reg;
+	char data[6];
+	for (i=1;i<=7;++i) {
+		reg = read16(i);
+		sprintf(data, "%04x:", reg);
+		Serial.print(data);
+	}
+	Serial.println("");
+}
 
 /**************************************************************************/
 /*! 
@@ -110,7 +120,7 @@ int Adafruit_MCP9808::shutdown_wake( uint8_t sw_ID )
 /**************************************************************************/
 
 void Adafruit_MCP9808::write16(uint8_t reg, uint16_t value) {
-    Wire.beginTransmission(_i2caddr);
+	Wire.beginTransmission(_i2caddr);
     Wire.write((uint8_t)reg);
     Wire.write(value >> 8);
     Wire.write(value & 0xFF);

--- a/Adafruit_MCP9808.h
+++ b/Adafruit_MCP9808.h
@@ -16,6 +16,7 @@
     v1.0  - First release
 */
 /**************************************************************************/
+#pragma once
 
 #if ARDUINO >= 100
  #include "Arduino.h"
@@ -57,6 +58,7 @@ class Adafruit_MCP9808 {
   float readTempF( void );
   float readTempC( void );
   int shutdown_wake( uint8_t sw_ID );
+  void regdump( );
 
   void write16(uint8_t reg, uint16_t val);
   uint16_t read16(uint8_t reg);

--- a/Adafruit_MCP9808.h
+++ b/Adafruit_MCP9808.h
@@ -16,7 +16,8 @@
     v1.0  - First release
 */
 /**************************************************************************/
-#pragma once
+#ifndef _ADAFRUIT_MCP9808_H
+#define _ADAFRUIT_MCP9808_H
 
 #if ARDUINO >= 100
  #include "Arduino.h"
@@ -58,7 +59,6 @@ class Adafruit_MCP9808 {
   float readTempF( void );
   float readTempC( void );
   int shutdown_wake( uint8_t sw_ID );
-  void regdump( );
 
   void write16(uint8_t reg, uint16_t val);
   uint16_t read16(uint8_t reg);
@@ -67,3 +67,4 @@ class Adafruit_MCP9808 {
 
   uint8_t _i2caddr;
 };
+#endif

--- a/examples/mcp9808test/mcp9808test.ino
+++ b/examples/mcp9808test/mcp9808test.ino
@@ -30,13 +30,13 @@ void loop() {
   Serial.println("wake up MCP9808.... "); // wake up MSP9808 - power consumption ~200 mikro Ampere
 
   tempsensor.shutdown_wake(0);   // Don't remove this line! required before reading temp
+  delay(250); // it takes 250ms for the device to wake up and set the correct temp 
 
   // Read and print out the temperature, then convert to *F
   float c = tempsensor.readTempC();
   float f = c * 9.0 / 5.0 + 32;
   Serial.print("Temp: "); Serial.print(c); Serial.print("*C\t"); 
   Serial.print(f); Serial.println("*F");
-  delay(250);
   
   Serial.println("Shutdown MCP9808.... ");
   tempsensor.shutdown_wake(1); // shutdown MSP9808 - power consumption ~0.1 mikro Ampere


### PR DESCRIPTION
I fixed two issues with the library.
1) Calling shutdown(0) twice causes the device to go to sleep.  Incorrect temperatures are then read because the device will keep the last temp in it's register in sleep mode.  Changed XOR to an AND to fix this issue (was mentioned in the issues section of this library, but nobody ever made a pull request for it)
2) The example should correctly show that the device needs 250ms after exiting sleep mode before the correct temperature is valid.  If this is not done, then the last temperature is read.
3) added standard header ifdefs in the .h file to allow the code to be referenced by another library without duplicate errors.
