### PR TITLE
Increase delay in wake for highest resolution

### DIFF
--- a/Adafruit_MCP9808.cpp
+++ b/Adafruit_MCP9808.cpp
@@ -174,7 +174,7 @@ void Adafruit_MCP9808::shutdown() { shutdown_wake(true); }
  */
 void Adafruit_MCP9808::wake() {
   shutdown_wake(false);
-  delay(250);
+  delay(260);
 }
 
 /*!


### PR DESCRIPTION
Using the sensor with setResolution(3) can cause the sensor to report
the previous measurement.

Increase the delay so that a conversion for all resolution modes works.

Users wanting to use a custom value for the delay could use:
shutdown_wake(false);
delay(custom_value);

Fixes: https://github.com/adafruit/Adafruit_MCP9808_Library/issues/26
