### PR TITLE
Added temperature alert configuration functions

### DIFF
--- a/Adafruit_MCP9808.cpp
+++ b/Adafruit_MCP9808.cpp
@@ -39,8 +39,9 @@ Adafruit_MCP9808::Adafruit_MCP9808() {}
  *    @param  *theWire
  *    @return True if initialization was successful, otherwise false.
  */
-bool Adafruit_MCP9808::begin(TwoWire *theWire) {
-  return begin(MCP9808_I2CADDR_DEFAULT, theWire);
+bool Adafruit_MCP9808::begin(TwoWire *theWire)
+{
+	return begin(MCP9808_I2CADDR_DEFAULT, theWire);
 }
 
 /*!
@@ -57,13 +58,15 @@ bool Adafruit_MCP9808::begin(uint8_t addr) { return begin(addr, &Wire); }
  *    @param  *theWire
  *    @return True if initialization was successful, otherwise false.
  */
-bool Adafruit_MCP9808::begin(uint8_t addr, TwoWire *theWire) {
-  if (i2c_dev) {
-    delete i2c_dev;
-  }
-  i2c_dev = new Adafruit_I2CDevice(addr, theWire);
+bool Adafruit_MCP9808::begin(uint8_t addr, TwoWire *theWire)
+{
+	if (i2c_dev)
+	{
+		delete i2c_dev;
+	}
+	i2c_dev = new Adafruit_I2CDevice(addr, theWire);
 
-  return init();
+	return init();
 }
 
 /*!
@@ -76,18 +79,20 @@ bool Adafruit_MCP9808::begin() { return begin(MCP9808_I2CADDR_DEFAULT, &Wire); }
  *    @brief  init function
  *    @return True if initialization was successful, otherwise false.
  */
-bool Adafruit_MCP9808::init() {
-  if (!i2c_dev->begin()) {
-    return false;
-  }
+bool Adafruit_MCP9808::init()
+{
+	if (!i2c_dev->begin())
+	{
+		return false;
+	}
 
-  if (read16(MCP9808_REG_MANUF_ID) != 0x0054)
-    return false;
-  if (read16(MCP9808_REG_DEVICE_ID) != 0x0400)
-    return false;
+	if (read16(MCP9808_REG_MANUF_ID) != 0x0054)
+		return false;
+	if (read16(MCP9808_REG_DEVICE_ID) != 0x0400)
+		return false;
 
-  write16(MCP9808_REG_CONFIG, 0x0);
-  return true;
+	write16(MCP9808_REG_CONFIG, 0x0);
+	return true;
 }
 
 /*!
@@ -95,18 +100,20 @@ bool Adafruit_MCP9808::init() {
  *           temperature as a float.
  *   @return Temperature in Centigrade.
  */
-float Adafruit_MCP9808::readTempC() {
-  float temp = NAN;
-  uint16_t t = read16(MCP9808_REG_AMBIENT_TEMP);
+float Adafruit_MCP9808::readTempC()
+{
+	float temp = NAN;
+	uint16_t t = read16(MCP9808_REG_AMBIENT_TEMP);
 
-  if (t != 0xFFFF) {
-    temp = t & 0x0FFF;
-    temp /= 16.0;
-    if (t & 0x1000)
-      temp -= 256;
-  }
+	if (t != 0xFFFF)
+	{
+		temp = t & 0x0FFF;
+		temp /= 16.0;
+		if (t & 0x1000)
+			temp -= 256;
+	}
 
-  return temp;
+	return temp;
 }
 
 /*!
@@ -114,37 +121,42 @@ float Adafruit_MCP9808::readTempC() {
  *           temperature as a float.
  *   @return Temperature in Fahrenheit.
  */
-float Adafruit_MCP9808::readTempF() {
-  float temp = NAN;
-  uint16_t t = read16(MCP9808_REG_AMBIENT_TEMP);
+float Adafruit_MCP9808::readTempF()
+{
+	float temp = NAN;
+	uint16_t t = read16(MCP9808_REG_AMBIENT_TEMP);
 
-  if (t != 0xFFFF) {
-    temp = t & 0x0FFF;
-    temp /= 16.0;
-    if (t & 0x1000)
-      temp -= 256;
+	if (t != 0xFFFF)
+	{
+		temp = t & 0x0FFF;
+		temp /= 16.0;
+		if (t & 0x1000)
+			temp -= 256;
 
-    temp = temp * 9.0 / 5.0 + 32;
-  }
+		temp = temp * 9.0 / 5.0 + 32;
+	}
 
-  return temp;
+	return temp;
 }
 
 /*!
  *   @brief  Set Sensor to Shutdown-State or wake up (Conf_Register BIT8)
  *   @param  sw true = shutdown / false = wakeup
  */
-void Adafruit_MCP9808::shutdown_wake(boolean sw) {
-  uint16_t conf_shutdown;
-  uint16_t conf_register = read16(MCP9808_REG_CONFIG);
-  if (sw == true) {
-    conf_shutdown = conf_register | MCP9808_REG_CONFIG_SHUTDOWN;
-    write16(MCP9808_REG_CONFIG, conf_shutdown);
-  }
-  if (sw == false) {
-    conf_shutdown = conf_register & ~MCP9808_REG_CONFIG_SHUTDOWN;
-    write16(MCP9808_REG_CONFIG, conf_shutdown);
-  }
+void Adafruit_MCP9808::shutdown_wake(boolean sw)
+{
+	uint16_t conf_shutdown;
+	uint16_t conf_register = read16(MCP9808_REG_CONFIG);
+	if (sw == true)
+	{
+		conf_shutdown = conf_register | MCP9808_REG_CONFIG_SHUTDOWN;
+		write16(MCP9808_REG_CONFIG, conf_shutdown);
+	}
+	if (sw == false)
+	{
+		conf_shutdown = conf_register & ~MCP9808_REG_CONFIG_SHUTDOWN;
+		write16(MCP9808_REG_CONFIG, conf_shutdown);
+	}
 }
 
 /*!
@@ -155,77 +167,87 @@ void Adafruit_MCP9808::shutdown() { shutdown_wake(true); }
 /*!
  *   @brief  Wake up MCP9808
  */
-void Adafruit_MCP9808::wake() {
-  shutdown_wake(false);
-  delay(260);
+void Adafruit_MCP9808::wake()
+{
+	shutdown_wake(false);
+	delay(260);
 }
 
 /*!
  *   @brief  Get Resolution Value
  *   @return Resolution value
  */
-uint8_t Adafruit_MCP9808::getResolution() {
-  return read8(MCP9808_REG_RESOLUTION);
+uint8_t Adafruit_MCP9808::getResolution()
+{
+	return read8(MCP9808_REG_RESOLUTION);
 }
 
 /*!
  *   @brief  Set Resolution Value
  *   @param  value
  */
-void Adafruit_MCP9808::setResolution(uint8_t value) {
-  write8(MCP9808_REG_RESOLUTION, value & 0x03);
+void Adafruit_MCP9808::setResolution(uint8_t value)
+{
+	write8(MCP9808_REG_RESOLUTION, value & 0x03);
 }
-
 
 /*!
  * @brief Convert temperature float to MCP9808 register format
  * @param temp Temperature in Celsius
  * @return 16-bit register value
  */
-uint16_t Adafruit_MCP9808::tempToReg(float temp) {
-  // Temperature is stored in 12 bits (11-0) with 0.25°C resolution for limit registers
-  // Bit 12 is sign bit, bits 15-13 should be 0
-  
-  int16_t tempInt;
-  uint16_t regValue;
-  
-  // Convert to 0.25°C resolution (shift left by 2 for bits 11-2)
-  tempInt = (int16_t)(temp / 0.25);
-  
-  if (temp < 0) {
-    // Two's complement for negative temperatures
-    regValue = (tempInt & 0x0FFF) | 0x1000;  // Set sign bit
-  } else {
-    regValue = tempInt & 0x0FFF;
-  }
-  
-  // Shift left by 2 to position in bits 11-2 (bits 1-0 are unused)
-  regValue = regValue << 2;
-  
-  return regValue;
+uint16_t Adafruit_MCP9808::tempToReg(float temp)
+{
+	// Temperature is stored in 12 bits (11-0) with 0.25°C resolution for limit registers
+	// Bit 12 is sign bit, bits 15-13 should be 0
+
+	int16_t tempInt;
+	uint16_t regValue;
+
+	// Convert to 0.25°C resolution (shift left by 2 for bits 11-2)
+	tempInt = (int16_t)(temp / 0.25);
+
+	if (temp < 0)
+	{
+		// Two's complement for negative temperatures
+		regValue = (tempInt & 0x0FFF) | 0x1000; // Set sign bit
+	}
+	else
+	{
+		regValue = tempInt & 0x0FFF;
+	}
+
+	// Shift left by 2 to position in bits 11-2 (bits 1-0 are unused)
+	regValue = regValue << 2;
+
+	return regValue;
 }
 
 /*!
  * @brief Convert MCP9808 register format to temperature float
- * @param reg 16-bit register value  
+ * @param reg 16-bit register value
  * @return Temperature in Celsius
  */
-float Adafruit_MCP9808::regToTemp(uint16_t reg) {
-  // Shift right by 2 to get actual temperature bits
-  reg = reg >> 2;
-  
-  float temp;
-  
-  // Check sign bit (bit 12 after shift, which is now bit 10)
-  if (reg & 0x1000) {
-    // Negative temperature
-    reg = reg & 0x0FFF;  // Clear sign bit
-    temp = -(256 - (reg * 0.25));
-  } else {
-    temp = reg * 0.25;
-  }
-  
-  return temp;
+float Adafruit_MCP9808::regToTemp(uint16_t reg)
+{
+	// Shift right by 2 to get actual temperature bits
+	reg = reg >> 2;
+
+	float temp;
+
+	// Check sign bit (bit 12 after shift, which is now bit 10)
+	if (reg & 0x1000)
+	{
+		// Negative temperature
+		reg = reg & 0x0FFF; // Clear sign bit
+		temp = -(256 - (reg * 0.25));
+	}
+	else
+	{
+		temp = reg * 0.25;
+	}
+
+	return temp;
 }
 
 /*!
@@ -233,14 +255,16 @@ float Adafruit_MCP9808::regToTemp(uint16_t reg) {
  * @param temp Temperature in Celsius (-40 to +125)
  * @return true on success
  */
-bool Adafruit_MCP9808::setUpperTemp(float temp) {
-  if (temp < -40.0 || temp > 125.0) {
-    return false;
-  }
-  
-  uint16_t regValue = tempToReg(temp);
-  write16(MCP9808_REG_UPPER_TEMP, regValue);
-  return true;
+bool Adafruit_MCP9808::setUpperTemp(float temp)
+{
+	if (temp < -40.0 || temp > 125.0)
+	{
+		return false;
+	}
+
+	uint16_t regValue = tempToReg(temp);
+	write16(MCP9808_REG_UPPER_TEMP, regValue);
+	return true;
 }
 
 /*!
@@ -248,19 +272,21 @@ bool Adafruit_MCP9808::setUpperTemp(float temp) {
  * @param temp Temperature in Celsius (-40 to +125)
  * @return true on success
  */
-bool Adafruit_MCP9808::setLowerTemp(float temp) {
-  if (temp < -40.0 || temp > 125.0) {
-    return false;
-  }
-  
-  uint16_t regValue = tempToReg(temp);
-  write16(MCP9808_REG_LOWER_TEMP, regValue);
-  return true;
+bool Adafruit_MCP9808::setLowerTemp(float temp)
+{
+	if (temp < -40.0 || temp > 125.0)
+	{
+		return false;
+	}
+
+	uint16_t regValue = tempToReg(temp);
+	write16(MCP9808_REG_LOWER_TEMP, regValue);
+	return true;
 }
 
 /*!
  * @brief Set temperature alert hysteresis
- * @param hyst Hysteresis value (MCP9808_HYST_0C, MCP9808_HYST_1_5C, 
+ * @param hyst Hysteresis value (MCP9808_HYST_0C, MCP9808_HYST_1_5C,
  *             MCP9808_HYST_3C, or MCP9808_HYST_6C)
  * @return true on success
  * @note Hysteresis applies when temperature decreases below the limit.
@@ -268,41 +294,44 @@ bool Adafruit_MCP9808::setLowerTemp(float temp) {
  *       - Alert asserts at 30.0°C
  *       - Alert deasserts at 28.5°C
  */
-bool Adafruit_MCP9808::setHysteresis(uint8_t hyst) {
-  uint16_t config = read16(MCP9808_REG_CONFIG);
-  
-  // Clear hysteresis bits (10-9)
-  config &= ~MCP9808_CONFIG_HYST_MASK;
-  
-  // Set new hysteresis value (shift hyst value to bits 10-9)
-  switch(hyst) {
-    case MCP9808_HYST_0C:
-      config |= MCP9808_CONFIG_HYST_0C;
-      break;
-    case MCP9808_HYST_1_5C:
-      config |= MCP9808_CONFIG_HYST_1_5C;
-      break;
-    case MCP9808_HYST_3C:
-      config |= MCP9808_CONFIG_HYST_3C;
-      break;
-    case MCP9808_HYST_6C:
-      config |= MCP9808_CONFIG_HYST_6C;
-      break;
-    default:
-      return false;
-  }
-  
-  write16(MCP9808_REG_CONFIG, config);
-  return true;
+bool Adafruit_MCP9808::setHysteresis(uint8_t hyst)
+{
+	uint16_t config = read16(MCP9808_REG_CONFIG);
+
+	// Clear hysteresis bits (10-9)
+	config &= ~MCP9808_CONFIG_HYST_MASK;
+
+	// Set new hysteresis value (shift hyst value to bits 10-9)
+	switch (hyst)
+	{
+	case MCP9808_HYST_0C:
+		config |= MCP9808_CONFIG_HYST_0C;
+		break;
+	case MCP9808_HYST_1_5C:
+		config |= MCP9808_CONFIG_HYST_1_5C;
+		break;
+	case MCP9808_HYST_3C:
+		config |= MCP9808_CONFIG_HYST_3C;
+		break;
+	case MCP9808_HYST_6C:
+		config |= MCP9808_CONFIG_HYST_6C;
+		break;
+	default:
+		return false;
+	}
+
+	write16(MCP9808_REG_CONFIG, config);
+	return true;
 }
 
 /*!
  * @brief Get current temperature alert hysteresis setting
  * @return Current hysteresis setting (0=0°C, 1=1.5°C, 2=3°C, 3=6°C)
  */
-uint8_t Adafruit_MCP9808::getHysteresis() {
-  uint16_t config = read16(MCP9808_REG_CONFIG);
-  return (config & MCP9808_CONFIG_HYST_MASK) >> 9;
+uint8_t Adafruit_MCP9808::getHysteresis()
+{
+	uint16_t config = read16(MCP9808_REG_CONFIG);
+	return (config & MCP9808_CONFIG_HYST_MASK) >> 9;
 }
 
 /*!
@@ -310,14 +339,16 @@ uint8_t Adafruit_MCP9808::getHysteresis() {
  * @param temp Temperature in Celsius (-40 to +125)
  * @return true on success
  */
-bool Adafruit_MCP9808::setCriticalTemp(float temp) {
-  if (temp < -40.0 || temp > 125.0) {
-    return false;
-  }
-  
-  uint16_t regValue = tempToReg(temp);
-  write16(MCP9808_REG_CRIT_TEMP, regValue);
-  return true;
+bool Adafruit_MCP9808::setCriticalTemp(float temp)
+{
+	if (temp < -40.0 || temp > 125.0)
+	{
+		return false;
+	}
+
+	uint16_t regValue = tempToReg(temp);
+	write16(MCP9808_REG_CRIT_TEMP, regValue);
+	return true;
 }
 
 /*!
@@ -325,17 +356,21 @@ bool Adafruit_MCP9808::setCriticalTemp(float temp) {
  * @param activeHigh true for active-high, false for active-low
  * @return true on success
  */
-bool Adafruit_MCP9808::setAlertPolarity(bool activeHigh) {
-  uint16_t config = read16(MCP9808_REG_CONFIG);
-  
-  if (activeHigh) {
-    config |= MCP9808_REG_CONFIG_ALERTPOL;
-  } else {
-    config &= ~MCP9808_REG_CONFIG_ALERTPOL;
-  }
-  
-  write16(MCP9808_REG_CONFIG, config);
-  return true;
+bool Adafruit_MCP9808::setAlertPolarity(bool activeHigh)
+{
+	uint16_t config = read16(MCP9808_REG_CONFIG);
+
+	if (activeHigh)
+	{
+		config |= MCP9808_REG_CONFIG_ALERTPOL;
+	}
+	else
+	{
+		config &= ~MCP9808_REG_CONFIG_ALERTPOL;
+	}
+
+	write16(MCP9808_REG_CONFIG, config);
+	return true;
 }
 
 /*!
@@ -343,17 +378,21 @@ bool Adafruit_MCP9808::setAlertPolarity(bool activeHigh) {
  * @param interruptMode true for interrupt mode, false for comparator mode
  * @return true on success
  */
-bool Adafruit_MCP9808::setAlertMode(bool interruptMode) {
-  uint16_t config = read16(MCP9808_REG_CONFIG);
-  
-  if (interruptMode) {
-    config |= MCP9808_REG_CONFIG_ALERTMODE;
-  } else {
-    config &= ~MCP9808_REG_CONFIG_ALERTMODE;
-  }
-  
-  write16(MCP9808_REG_CONFIG, config);
-  return true;
+bool Adafruit_MCP9808::setAlertMode(bool interruptMode)
+{
+	uint16_t config = read16(MCP9808_REG_CONFIG);
+
+	if (interruptMode)
+	{
+		config |= MCP9808_REG_CONFIG_ALERTMODE;
+	}
+	else
+	{
+		config &= ~MCP9808_REG_CONFIG_ALERTMODE;
+	}
+
+	write16(MCP9808_REG_CONFIG, config);
+	return true;
 }
 
 /*!
@@ -361,17 +400,21 @@ bool Adafruit_MCP9808::setAlertMode(bool interruptMode) {
  * @param enable true to enable, false to disable
  * @return true on success
  */
-bool Adafruit_MCP9808::enableAlert(bool enable) {
-  uint16_t config = read16(MCP9808_REG_CONFIG);
-  
-  if (enable) {
-    config |= MCP9808_REG_CONFIG_ALERTCTRL;
-  } else {
-    config &= ~MCP9808_REG_CONFIG_ALERTCTRL;
-  }
-  
-  write16(MCP9808_REG_CONFIG, config);
-  return true;
+bool Adafruit_MCP9808::enableAlert(bool enable)
+{
+	uint16_t config = read16(MCP9808_REG_CONFIG);
+
+	if (enable)
+	{
+		config |= MCP9808_REG_CONFIG_ALERTCTRL;
+	}
+	else
+	{
+		config &= ~MCP9808_REG_CONFIG_ALERTCTRL;
+	}
+
+	write16(MCP9808_REG_CONFIG, config);
+	return true;
 }
 
 /*!
@@ -380,22 +423,26 @@ bool Adafruit_MCP9808::enableAlert(bool enable) {
  *                 - true: Alert only for TCRIT (critical temperature only)
  *                 - false: Alert for TUPPER, TLOWER, and TCRIT (window + critical)
  * @return true on success
- * 
+ *
  * @note By default, the MCP9808 monitors all three boundaries (TUPPER, TLOWER, TCRIT).
  *       Set to true when using only setCriticalTemp() for simple over-temperature alerts.
  *       Set to false when using setUpperTemp() and setLowerTemp() for temperature window monitoring.
  */
-bool Adafruit_MCP9808::setAlertSelectCriticalOnly(bool critOnly) {
-  uint16_t config = read16(MCP9808_REG_CONFIG);
-  
-  if (critOnly) {
-    config |= MCP9808_REG_CONFIG_ALERTSEL;   // Set bit 2 - critical only
-  } else {
-    config &= ~MCP9808_REG_CONFIG_ALERTSEL;  // Clear bit 2 - all boundaries
-  }
-  
-  write16(MCP9808_REG_CONFIG, config);
-  return true;
+bool Adafruit_MCP9808::setAlertSelectCriticalOnly(bool critOnly)
+{
+	uint16_t config = read16(MCP9808_REG_CONFIG);
+
+	if (critOnly)
+	{
+		config |= MCP9808_REG_CONFIG_ALERTSEL; // Set bit 2 - critical only
+	}
+	else
+	{
+		config &= ~MCP9808_REG_CONFIG_ALERTSEL; // Clear bit 2 - all boundaries
+	}
+
+	write16(MCP9808_REG_CONFIG, config);
+	return true;
 }
 
 /*!
@@ -415,75 +462,81 @@ bool Adafruit_MCP9808::setAlertSelectCriticalOnly(bool critOnly) {
  * @param critOnly Use the critical temperature only
  * @return true on success, false if temperature out of range
  */
-bool Adafruit_MCP9808::setTempAlert(float temp, bool activeHigh, bool alertMode, uint8_t hysteresis, bool critOnly) {
-  // Set critical temperature
-  if (!setCriticalTemp(temp)) {
-    return false;
-  }
-  
-  // Set polarity
-  setAlertPolarity(activeHigh);
-  
-  // Set to comparator mode (typical for simple alerts)
-  setAlertMode(alertMode);
+bool Adafruit_MCP9808::setTempAlert(float temp, bool activeHigh, bool alertMode, uint8_t hysteresis, bool critOnly)
+{
+	// Set critical temperature
+	if (!setCriticalTemp(temp))
+	{
+		return false;
+	}
 
-  setHysteresis(hysteresis);
+	// Set polarity
+	setAlertPolarity(activeHigh);
 
-  setAlertSelectCriticalOnly(critOnly);
-  
-  // Enable alert output
-  enableAlert(true);
-  
-  return true;
+	// Set to comparator mode (typical for simple alerts)
+	setAlertMode(alertMode);
+
+	setHysteresis(hysteresis);
+
+	setAlertSelectCriticalOnly(critOnly);
+
+	// Enable alert output
+	enableAlert(true);
+
+	return true;
 }
 
 /*!
  * @brief Get upper temperature boundary
  * @return Temperature in Celsius
  */
-float Adafruit_MCP9808::getUpperTemp() {
-  uint16_t reg = read16(MCP9808_REG_UPPER_TEMP);
-  return regToTemp(reg);
+float Adafruit_MCP9808::getUpperTemp()
+{
+	uint16_t reg = read16(MCP9808_REG_UPPER_TEMP);
+	return regToTemp(reg);
 }
 
 /*!
  * @brief Get lower temperature boundary
  * @return Temperature in Celsius
  */
-float Adafruit_MCP9808::getLowerTemp() {
-  uint16_t reg = read16(MCP9808_REG_LOWER_TEMP);
-  return regToTemp(reg);
+float Adafruit_MCP9808::getLowerTemp()
+{
+	uint16_t reg = read16(MCP9808_REG_LOWER_TEMP);
+	return regToTemp(reg);
 }
 
 /*!
  * @brief Get critical temperature boundary
  * @return Temperature in Celsius
  */
-float Adafruit_MCP9808::getCriticalTemp() {
-  uint16_t reg = read16(MCP9808_REG_CRIT_TEMP);
-  return regToTemp(reg);
+float Adafruit_MCP9808::getCriticalTemp()
+{
+	uint16_t reg = read16(MCP9808_REG_CRIT_TEMP);
+	return regToTemp(reg);
 }
 
 /*!
  * @brief Check if alert is currently asserted
  * @return true if alert condition is met
  */
-bool Adafruit_MCP9808::getAlertStatus() {
-  uint16_t config = read16(MCP9808_REG_CONFIG);
-  return (config & 0x0010) != 0;  // Bit 4 is Alert Status
+bool Adafruit_MCP9808::getAlertStatus()
+{
+	uint16_t config = read16(MCP9808_REG_CONFIG);
+	return (config & 0x0010) != 0; // Bit 4 is Alert Status
 }
-
 
 /*!
  *    @brief  Low level 16 bit write procedures
  *    @param  reg
  *    @param  value
  */
-void Adafruit_MCP9808::write16(uint8_t reg, uint16_t value) {
-  Adafruit_BusIO_Register reg16 =
-      Adafruit_BusIO_Register(i2c_dev, reg, 2, MSBFIRST);
+void Adafruit_MCP9808::write16(uint8_t reg, uint16_t value)
+{
+	Adafruit_BusIO_Register reg16 =
+		Adafruit_BusIO_Register(i2c_dev, reg, 2, MSBFIRST);
 
-  reg16.write(value);
+	reg16.write(value);
 }
 
 /*!
@@ -491,11 +544,12 @@ void Adafruit_MCP9808::write16(uint8_t reg, uint16_t value) {
  *    @param  reg
  *    @return value
  */
-uint16_t Adafruit_MCP9808::read16(uint8_t reg) {
-  Adafruit_BusIO_Register reg16 =
-      Adafruit_BusIO_Register(i2c_dev, reg, 2, MSBFIRST);
+uint16_t Adafruit_MCP9808::read16(uint8_t reg)
+{
+	Adafruit_BusIO_Register reg16 =
+		Adafruit_BusIO_Register(i2c_dev, reg, 2, MSBFIRST);
 
-  return reg16.read();
+	return reg16.read();
 }
 
 /*!
@@ -503,10 +557,11 @@ uint16_t Adafruit_MCP9808::read16(uint8_t reg) {
  *    @param  reg
  *    @param  value
  */
-void Adafruit_MCP9808::write8(uint8_t reg, uint8_t value) {
-  Adafruit_BusIO_Register reg8 = Adafruit_BusIO_Register(i2c_dev, reg, 1);
+void Adafruit_MCP9808::write8(uint8_t reg, uint8_t value)
+{
+	Adafruit_BusIO_Register reg8 = Adafruit_BusIO_Register(i2c_dev, reg, 1);
 
-  reg8.write(value);
+	reg8.write(value);
 }
 
 /*!
@@ -514,54 +569,57 @@ void Adafruit_MCP9808::write8(uint8_t reg, uint8_t value) {
  *    @param  reg
  *    @return value
  */
-uint8_t Adafruit_MCP9808::read8(uint8_t reg) {
-  Adafruit_BusIO_Register reg8 = Adafruit_BusIO_Register(i2c_dev, reg, 1);
+uint8_t Adafruit_MCP9808::read8(uint8_t reg)
+{
+	Adafruit_BusIO_Register reg8 = Adafruit_BusIO_Register(i2c_dev, reg, 1);
 
-  return reg8.read();
+	return reg8.read();
 }
 
 /**************************************************************************/
 /*!
-    @brief  Gets the pressure sensor and temperature values as sensor events
+	@brief  Gets the pressure sensor and temperature values as sensor events
 
-    @param  temp Sensor event object that will be populated with temp data
-    @returns True
+	@param  temp Sensor event object that will be populated with temp data
+	@returns True
 */
 /**************************************************************************/
-bool Adafruit_MCP9808::getEvent(sensors_event_t *temp) {
-  uint32_t t = millis();
+bool Adafruit_MCP9808::getEvent(sensors_event_t *temp)
+{
+	uint32_t t = millis();
 
-  // use helpers to fill in the events
-  memset(temp, 0, sizeof(sensors_event_t));
-  temp->version = sizeof(sensors_event_t);
-  temp->sensor_id = _sensorID;
-  temp->type = SENSOR_TYPE_AMBIENT_TEMPERATURE;
-  temp->timestamp = t;
-  temp->temperature = readTempC();
-  return true;
+	// use helpers to fill in the events
+	memset(temp, 0, sizeof(sensors_event_t));
+	temp->version = sizeof(sensors_event_t);
+	temp->sensor_id = _sensorID;
+	temp->type = SENSOR_TYPE_AMBIENT_TEMPERATURE;
+	temp->timestamp = t;
+	temp->temperature = readTempC();
+	return true;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Gets the overall sensor_t data including the type, range and
+	@brief  Gets the overall sensor_t data including the type, range and
    resulution
-    @param  sensor Pointer to Adafruit_Sensor sensor_t object that will be
+	@param  sensor Pointer to Adafruit_Sensor sensor_t object that will be
    filled with sensor type data
 */
 /**************************************************************************/
-void Adafruit_MCP9808::getSensor(sensor_t *sensor) {
-  /* Clear the sensor_t object */
-  memset(sensor, 0, sizeof(sensor_t));
+void Adafruit_MCP9808::getSensor(sensor_t *sensor)
+{
+	/* Clear the sensor_t object */
+	memset(sensor, 0, sizeof(sensor_t));
 
-  /* Insert the sensor name in the fixed length char array */
-  strncpy(sensor->name, "MCP9808", sizeof(sensor->name) - 1);
-  sensor->name[sizeof(sensor->name) - 1] = 0;
-  sensor->version = 1;
-  sensor->sensor_id = _sensorID;
-  sensor->type = SENSOR_TYPE_AMBIENT_TEMPERATURE;
-  sensor->min_delay = 0;
-  sensor->max_value = 100.0;
-  sensor->min_value = -20.0;
-  sensor->resolution = 0.0625;
+	/* Insert the sensor name in the fixed length char array */
+	strncpy(sensor->name, "MCP9808", sizeof(sensor->name) - 1);
+	sensor->name[sizeof(sensor->name) - 1] = 0;
+	sensor->version = 1;
+	sensor->sensor_id = _sensorID;
+	sensor->type = SENSOR_TYPE_AMBIENT_TEMPERATURE;
+	sensor->min_delay = 0;
+	sensor->max_value = 100.0;
+	sensor->min_value = -20.0;
+	sensor->resolution = 0.0625;
 }
 /*******************************************************/

--- a/Adafruit_MCP9808.cpp
+++ b/Adafruit_MCP9808.cpp
@@ -176,6 +176,304 @@ void Adafruit_MCP9808::setResolution(uint8_t value) {
   write8(MCP9808_REG_RESOLUTION, value & 0x03);
 }
 
+
+/*!
+ * @brief Convert temperature float to MCP9808 register format
+ * @param temp Temperature in Celsius
+ * @return 16-bit register value
+ */
+uint16_t Adafruit_MCP9808::tempToReg(float temp) {
+  // Temperature is stored in 12 bits (11-0) with 0.25°C resolution for limit registers
+  // Bit 12 is sign bit, bits 15-13 should be 0
+  
+  int16_t tempInt;
+  uint16_t regValue;
+  
+  // Convert to 0.25°C resolution (shift left by 2 for bits 11-2)
+  tempInt = (int16_t)(temp / 0.25);
+  
+  if (temp < 0) {
+    // Two's complement for negative temperatures
+    regValue = (tempInt & 0x0FFF) | 0x1000;  // Set sign bit
+  } else {
+    regValue = tempInt & 0x0FFF;
+  }
+  
+  // Shift left by 2 to position in bits 11-2 (bits 1-0 are unused)
+  regValue = regValue << 2;
+  
+  return regValue;
+}
+
+/*!
+ * @brief Convert MCP9808 register format to temperature float
+ * @param reg 16-bit register value  
+ * @return Temperature in Celsius
+ */
+float Adafruit_MCP9808::regToTemp(uint16_t reg) {
+  // Shift right by 2 to get actual temperature bits
+  reg = reg >> 2;
+  
+  float temp;
+  
+  // Check sign bit (bit 12 after shift, which is now bit 10)
+  if (reg & 0x1000) {
+    // Negative temperature
+    reg = reg & 0x0FFF;  // Clear sign bit
+    temp = -(256 - (reg * 0.25));
+  } else {
+    temp = reg * 0.25;
+  }
+  
+  return temp;
+}
+
+/*!
+ * @brief Set upper temperature boundary
+ * @param temp Temperature in Celsius (-40 to +125)
+ * @return true on success
+ */
+bool Adafruit_MCP9808::setUpperTemp(float temp) {
+  if (temp < -40.0 || temp > 125.0) {
+    return false;
+  }
+  
+  uint16_t regValue = tempToReg(temp);
+  write16(MCP9808_REG_UPPER_TEMP, regValue);
+  return true;
+}
+
+/*!
+ * @brief Set lower temperature boundary
+ * @param temp Temperature in Celsius (-40 to +125)
+ * @return true on success
+ */
+bool Adafruit_MCP9808::setLowerTemp(float temp) {
+  if (temp < -40.0 || temp > 125.0) {
+    return false;
+  }
+  
+  uint16_t regValue = tempToReg(temp);
+  write16(MCP9808_REG_LOWER_TEMP, regValue);
+  return true;
+}
+
+/*!
+ * @brief Set temperature alert hysteresis
+ * @param hyst Hysteresis value (MCP9808_HYST_0C, MCP9808_HYST_1_5C, 
+ *             MCP9808_HYST_3C, or MCP9808_HYST_6C)
+ * @return true on success
+ * @note Hysteresis applies when temperature decreases below the limit.
+ *       For example, with TCRIT=30°C and 1.5°C hysteresis:
+ *       - Alert asserts at 30.0°C
+ *       - Alert deasserts at 28.5°C
+ */
+bool Adafruit_MCP9808::setHysteresis(uint8_t hyst) {
+  uint16_t config = read16(MCP9808_REG_CONFIG);
+  
+  // Clear hysteresis bits (10-9)
+  config &= ~MCP9808_CONFIG_HYST_MASK;
+  
+  // Set new hysteresis value (shift hyst value to bits 10-9)
+  switch(hyst) {
+    case MCP9808_HYST_0C:
+      config |= MCP9808_CONFIG_HYST_0C;
+      break;
+    case MCP9808_HYST_1_5C:
+      config |= MCP9808_CONFIG_HYST_1_5C;
+      break;
+    case MCP9808_HYST_3C:
+      config |= MCP9808_CONFIG_HYST_3C;
+      break;
+    case MCP9808_HYST_6C:
+      config |= MCP9808_CONFIG_HYST_6C;
+      break;
+    default:
+      return false;
+  }
+  
+  write16(MCP9808_REG_CONFIG, config);
+  return true;
+}
+
+/*!
+ * @brief Get current temperature alert hysteresis setting
+ * @return Current hysteresis setting (0=0°C, 1=1.5°C, 2=3°C, 3=6°C)
+ */
+uint8_t Adafruit_MCP9808::getHysteresis() {
+  uint16_t config = read16(MCP9808_REG_CONFIG);
+  return (config & MCP9808_CONFIG_HYST_MASK) >> 9;
+}
+
+/*!
+ * @brief Set critical temperature boundary
+ * @param temp Temperature in Celsius (-40 to +125)
+ * @return true on success
+ */
+bool Adafruit_MCP9808::setCriticalTemp(float temp) {
+  if (temp < -40.0 || temp > 125.0) {
+    return false;
+  }
+  
+  uint16_t regValue = tempToReg(temp);
+  write16(MCP9808_REG_CRIT_TEMP, regValue);
+  return true;
+}
+
+/*!
+ * @brief Set alert output polarity
+ * @param activeHigh true for active-high, false for active-low
+ * @return true on success
+ */
+bool Adafruit_MCP9808::setAlertPolarity(bool activeHigh) {
+  uint16_t config = read16(MCP9808_REG_CONFIG);
+  
+  if (activeHigh) {
+    config |= MCP9808_REG_CONFIG_ALERTPOL;
+  } else {
+    config &= ~MCP9808_REG_CONFIG_ALERTPOL;
+  }
+  
+  write16(MCP9808_REG_CONFIG, config);
+  return true;
+}
+
+/*!
+ * @brief Set alert output mode
+ * @param interruptMode true for interrupt mode, false for comparator mode
+ * @return true on success
+ */
+bool Adafruit_MCP9808::setAlertMode(bool interruptMode) {
+  uint16_t config = read16(MCP9808_REG_CONFIG);
+  
+  if (interruptMode) {
+    config |= MCP9808_REG_CONFIG_ALERTMODE;
+  } else {
+    config &= ~MCP9808_REG_CONFIG_ALERTMODE;
+  }
+  
+  write16(MCP9808_REG_CONFIG, config);
+  return true;
+}
+
+/*!
+ * @brief Enable or disable alert output
+ * @param enable true to enable, false to disable
+ * @return true on success
+ */
+bool Adafruit_MCP9808::enableAlert(bool enable) {
+  uint16_t config = read16(MCP9808_REG_CONFIG);
+  
+  if (enable) {
+    config |= MCP9808_REG_CONFIG_ALERTCTRL;
+  } else {
+    config &= ~MCP9808_REG_CONFIG_ALERTCTRL;
+  }
+  
+  write16(MCP9808_REG_CONFIG, config);
+  return true;
+}
+
+/*!
+ * @brief Configure which temperature boundaries trigger the alert output
+ * @param critOnly Alert selection mode
+ *                 - true: Alert only for TCRIT (critical temperature only)
+ *                 - false: Alert for TUPPER, TLOWER, and TCRIT (window + critical)
+ * @return true on success
+ * 
+ * @note By default, the MCP9808 monitors all three boundaries (TUPPER, TLOWER, TCRIT).
+ *       Set to true when using only setCriticalTemp() for simple over-temperature alerts.
+ *       Set to false when using setUpperTemp() and setLowerTemp() for temperature window monitoring.
+ */
+bool Adafruit_MCP9808::setAlertSelectCriticalOnly(bool critOnly) {
+  uint16_t config = read16(MCP9808_REG_CONFIG);
+  
+  if (critOnly) {
+    config |= MCP9808_REG_CONFIG_ALERTSEL;   // Set bit 2 - critical only
+  } else {
+    config &= ~MCP9808_REG_CONFIG_ALERTSEL;  // Clear bit 2 - all boundaries
+  }
+  
+  write16(MCP9808_REG_CONFIG, config);
+  return true;
+}
+
+/*!
+ * @brief Convenience function to configure critical temperature alert
+ * @param temp Critical temperature threshold in Celsius (-40 to +125)
+ * @param activeHigh Alert output polarity
+ *                   - true: Active-high (alert pin goes HIGH when triggered)
+ *                   - false: Active-low (alert pin goes LOW when triggered)
+ * @param alertMode Alert output mode
+ *                  - true: Interrupt mode (latching, requires clearInterrupt())
+ *                  - false: Comparator mode (automatic, typical for hardware control)
+ * @param hysteresis Temperature hysteresis for deassert threshold
+ *                   - 0 or MCP9808_HYST_0C: 0°C (no hysteresis)
+ *                   - 1 or MCP9808_HYST_1_5C: 1.5°C
+ *                   - 2 or MCP9808_HYST_3C: 3.0°C
+ *                   - 3 or MCP9808_HYST_6C: 6.0°C
+ * @param critOnly Use the critical temperature only
+ * @return true on success, false if temperature out of range
+ */
+bool Adafruit_MCP9808::setTempAlert(float temp, bool activeHigh, bool alertMode, uint8_t hysteresis, bool critOnly) {
+  // Set critical temperature
+  if (!setCriticalTemp(temp)) {
+    return false;
+  }
+  
+  // Set polarity
+  setAlertPolarity(activeHigh);
+  
+  // Set to comparator mode (typical for simple alerts)
+  setAlertMode(alertMode);
+
+  setHysteresis(hysteresis);
+
+  setAlertSelectCriticalOnly(critOnly);
+  
+  // Enable alert output
+  enableAlert(true);
+  
+  return true;
+}
+
+/*!
+ * @brief Get upper temperature boundary
+ * @return Temperature in Celsius
+ */
+float Adafruit_MCP9808::getUpperTemp() {
+  uint16_t reg = read16(MCP9808_REG_UPPER_TEMP);
+  return regToTemp(reg);
+}
+
+/*!
+ * @brief Get lower temperature boundary
+ * @return Temperature in Celsius
+ */
+float Adafruit_MCP9808::getLowerTemp() {
+  uint16_t reg = read16(MCP9808_REG_LOWER_TEMP);
+  return regToTemp(reg);
+}
+
+/*!
+ * @brief Get critical temperature boundary
+ * @return Temperature in Celsius
+ */
+float Adafruit_MCP9808::getCriticalTemp() {
+  uint16_t reg = read16(MCP9808_REG_CRIT_TEMP);
+  return regToTemp(reg);
+}
+
+/*!
+ * @brief Check if alert is currently asserted
+ * @return true if alert condition is met
+ */
+bool Adafruit_MCP9808::getAlertStatus() {
+  uint16_t config = read16(MCP9808_REG_CONFIG);
+  return (config & 0x0010) != 0;  // Bit 4 is Alert Status
+}
+
+
 /*!
  *    @brief  Low level 16 bit write procedures
  *    @param  reg

--- a/Adafruit_MCP9808.h
+++ b/Adafruit_MCP9808.h
@@ -43,6 +43,17 @@
 #define MCP9808_REG_DEVICE_ID 0x07    ///< device ID
 #define MCP9808_REG_RESOLUTION 0x08   ///< resolutin
 
+#define MCP9808_CONFIG_HYST_0C   0x0000  // Bits 10-9 = 00
+#define MCP9808_CONFIG_HYST_1_5C 0x0200  // Bits 10-9 = 01
+#define MCP9808_CONFIG_HYST_3C   0x0400  // Bits 10-9 = 10
+#define MCP9808_CONFIG_HYST_6C   0x0600  // Bits 10-9 = 11
+#define MCP9808_CONFIG_HYST_MASK 0x0600  // Mask for bits 10-9
+
+#define MCP9808_HYST_0C 		0
+#define MCP9808_HYST_1_5C		1
+#define MCP9808_HYST_3C			2
+#define MCP9808_HYST_6C			3
+
 /*!
  *    @brief  Class that stores state and functions for interacting with
  *            MCP9808 Temp Sensor
@@ -65,6 +76,27 @@ public:
   void shutdown();
   void wake();
 
+	// Temperature alert configuration functions
+  bool setUpperTemp(float temp);
+  bool setLowerTemp(float temp);
+  bool setCriticalTemp(float temp);
+  bool setAlertPolarity(bool activeHigh);
+  bool setAlertMode(bool interruptMode);
+  bool enableAlert(bool enable);
+  bool setAlertSelectCriticalOnly(bool critOnly);
+  
+	bool setHysteresis(uint8_t hyst);
+	uint8_t getHysteresis();
+
+  // Convenience function - sets critical temp and polarity, enables alert
+  bool setTempAlert(float temp, bool activeHigh, bool alertMode, uint8_t hysteresis, bool critOnly);
+  
+  // Read alert settings
+  float getUpperTemp();
+  float getLowerTemp();
+  float getCriticalTemp();
+  bool getAlertStatus();
+
   void write16(uint8_t reg, uint16_t val);
   uint16_t read16(uint8_t reg);
 
@@ -78,6 +110,9 @@ public:
 private:
   uint16_t _sensorID = 9808; ///< ID number for temperature
   Adafruit_I2CDevice *i2c_dev = NULL;
+  /* Helper Functions */
+  uint16_t tempToReg(float temp);
+  float regToTemp(uint16_t reg);
 };
 
 #endif

--- a/Adafruit_MCP9808.h
+++ b/Adafruit_MCP9808.h
@@ -23,96 +23,97 @@
 #include <Adafruit_Sensor.h>
 
 #define MCP9808_I2CADDR_DEFAULT 0x18 ///< I2C address
-#define MCP9808_REG_CONFIG 0x01      ///< MCP9808 config register
+#define MCP9808_REG_CONFIG 0x01		 ///< MCP9808 config register
 
-#define MCP9808_REG_CONFIG_SHUTDOWN 0x0100   ///< shutdown config
+#define MCP9808_REG_CONFIG_SHUTDOWN 0x0100	 ///< shutdown config
 #define MCP9808_REG_CONFIG_CRITLOCKED 0x0080 ///< critical trip lock
-#define MCP9808_REG_CONFIG_WINLOCKED 0x0040  ///< alarm window lock
-#define MCP9808_REG_CONFIG_INTCLR 0x0020     ///< interrupt clear
-#define MCP9808_REG_CONFIG_ALERTSTAT 0x0010  ///< alert output status
-#define MCP9808_REG_CONFIG_ALERTCTRL 0x0008  ///< alert output control
-#define MCP9808_REG_CONFIG_ALERTSEL 0x0004   ///< alert output select
-#define MCP9808_REG_CONFIG_ALERTPOL 0x0002   ///< alert output polarity
-#define MCP9808_REG_CONFIG_ALERTMODE 0x0001  ///< alert output mode
+#define MCP9808_REG_CONFIG_WINLOCKED 0x0040	 ///< alarm window lock
+#define MCP9808_REG_CONFIG_INTCLR 0x0020	 ///< interrupt clear
+#define MCP9808_REG_CONFIG_ALERTSTAT 0x0010	 ///< alert output status
+#define MCP9808_REG_CONFIG_ALERTCTRL 0x0008	 ///< alert output control
+#define MCP9808_REG_CONFIG_ALERTSEL 0x0004	 ///< alert output select
+#define MCP9808_REG_CONFIG_ALERTPOL 0x0002	 ///< alert output polarity
+#define MCP9808_REG_CONFIG_ALERTMODE 0x0001	 ///< alert output mode
 
-#define MCP9808_REG_UPPER_TEMP 0x02   ///< upper alert boundary
-#define MCP9808_REG_LOWER_TEMP 0x03   ///< lower alert boundery
-#define MCP9808_REG_CRIT_TEMP 0x04    ///< critical temperature
+#define MCP9808_REG_UPPER_TEMP 0x02	  ///< upper alert boundary
+#define MCP9808_REG_LOWER_TEMP 0x03	  ///< lower alert boundery
+#define MCP9808_REG_CRIT_TEMP 0x04	  ///< critical temperature
 #define MCP9808_REG_AMBIENT_TEMP 0x05 ///< ambient temperature
-#define MCP9808_REG_MANUF_ID 0x06     ///< manufacture ID
-#define MCP9808_REG_DEVICE_ID 0x07    ///< device ID
-#define MCP9808_REG_RESOLUTION 0x08   ///< resolutin
+#define MCP9808_REG_MANUF_ID 0x06	  ///< manufacture ID
+#define MCP9808_REG_DEVICE_ID 0x07	  ///< device ID
+#define MCP9808_REG_RESOLUTION 0x08	  ///< resolutin
 
-#define MCP9808_CONFIG_HYST_0C   0x0000  // Bits 10-9 = 00
-#define MCP9808_CONFIG_HYST_1_5C 0x0200  // Bits 10-9 = 01
-#define MCP9808_CONFIG_HYST_3C   0x0400  // Bits 10-9 = 10
-#define MCP9808_CONFIG_HYST_6C   0x0600  // Bits 10-9 = 11
-#define MCP9808_CONFIG_HYST_MASK 0x0600  // Mask for bits 10-9
+#define MCP9808_CONFIG_HYST_0C 0x0000	// Bits 10-9 = 00
+#define MCP9808_CONFIG_HYST_1_5C 0x0200 // Bits 10-9 = 01
+#define MCP9808_CONFIG_HYST_3C 0x0400	// Bits 10-9 = 10
+#define MCP9808_CONFIG_HYST_6C 0x0600	// Bits 10-9 = 11
+#define MCP9808_CONFIG_HYST_MASK 0x0600 // Mask for bits 10-9
 
-#define MCP9808_HYST_0C 		0
-#define MCP9808_HYST_1_5C		1
-#define MCP9808_HYST_3C			2
-#define MCP9808_HYST_6C			3
+#define MCP9808_HYST_0C 0
+#define MCP9808_HYST_1_5C 1
+#define MCP9808_HYST_3C 2
+#define MCP9808_HYST_6C 3
 
 /*!
  *    @brief  Class that stores state and functions for interacting with
  *            MCP9808 Temp Sensor
  */
-class Adafruit_MCP9808 : public Adafruit_Sensor {
+class Adafruit_MCP9808 : public Adafruit_Sensor
+{
 public:
-  Adafruit_MCP9808();
-  bool begin();
-  bool begin(TwoWire *theWire);
-  bool begin(uint8_t addr);
-  bool begin(uint8_t addr, TwoWire *theWire);
+	Adafruit_MCP9808();
+	bool begin();
+	bool begin(TwoWire *theWire);
+	bool begin(uint8_t addr);
+	bool begin(uint8_t addr, TwoWire *theWire);
 
-  bool init();
-  float readTempC();
-  float readTempF();
-  uint8_t getResolution(void);
-  void setResolution(uint8_t value);
+	bool init();
+	float readTempC();
+	float readTempF();
+	uint8_t getResolution(void);
+	void setResolution(uint8_t value);
 
-  void shutdown_wake(boolean sw);
-  void shutdown();
-  void wake();
+	void shutdown_wake(boolean sw);
+	void shutdown();
+	void wake();
 
 	// Temperature alert configuration functions
-  bool setUpperTemp(float temp);
-  bool setLowerTemp(float temp);
-  bool setCriticalTemp(float temp);
-  bool setAlertPolarity(bool activeHigh);
-  bool setAlertMode(bool interruptMode);
-  bool enableAlert(bool enable);
-  bool setAlertSelectCriticalOnly(bool critOnly);
-  
+	bool setUpperTemp(float temp);
+	bool setLowerTemp(float temp);
+	bool setCriticalTemp(float temp);
+	bool setAlertPolarity(bool activeHigh);
+	bool setAlertMode(bool interruptMode);
+	bool enableAlert(bool enable);
+	bool setAlertSelectCriticalOnly(bool critOnly);
+
 	bool setHysteresis(uint8_t hyst);
 	uint8_t getHysteresis();
 
-  // Convenience function - sets critical temp and polarity, enables alert
-  bool setTempAlert(float temp, bool activeHigh, bool alertMode, uint8_t hysteresis, bool critOnly);
-  
-  // Read alert settings
-  float getUpperTemp();
-  float getLowerTemp();
-  float getCriticalTemp();
-  bool getAlertStatus();
+	// Convenience function - sets critical temp and polarity, enables alert
+	bool setTempAlert(float temp, bool activeHigh, bool alertMode, uint8_t hysteresis, bool critOnly);
 
-  void write16(uint8_t reg, uint16_t val);
-  uint16_t read16(uint8_t reg);
+	// Read alert settings
+	float getUpperTemp();
+	float getLowerTemp();
+	float getCriticalTemp();
+	bool getAlertStatus();
 
-  void write8(uint8_t reg, uint8_t val);
-  uint8_t read8(uint8_t reg);
+	void write16(uint8_t reg, uint16_t val);
+	uint16_t read16(uint8_t reg);
 
-  /* Unified Sensor API Functions */
-  bool getEvent(sensors_event_t *);
-  void getSensor(sensor_t *);
+	void write8(uint8_t reg, uint8_t val);
+	uint8_t read8(uint8_t reg);
+
+	/* Unified Sensor API Functions */
+	bool getEvent(sensors_event_t *);
+	void getSensor(sensor_t *);
 
 private:
-  uint16_t _sensorID = 9808; ///< ID number for temperature
-  Adafruit_I2CDevice *i2c_dev = NULL;
-  /* Helper Functions */
-  uint16_t tempToReg(float temp);
-  float regToTemp(uint16_t reg);
+	uint16_t _sensorID = 9808; ///< ID number for temperature
+	Adafruit_I2CDevice *i2c_dev = NULL;
+	/* Helper Functions */
+	uint16_t tempToReg(float temp);
+	float regToTemp(uint16_t reg);
 };
 
 #endif


### PR DESCRIPTION
## Description

This PR adds temperature alert configuration functionality to the MCP9808 library, enabling users to configure and use the built-in alert output feature of the MCP9808 sensor.

## New Features

### Alert Configuration Functions
- `setTempAlert(temp, activeHigh, alertMode, hysteresis)` - Convenient one-function alert setup
- `setUpperTemp(temp)` / `getUpperTemp()` - Upper temperature boundary
- `setLowerTemp(temp)` / `getLowerTemp()` - Lower temperature boundary  
- `setCriticalTemp(temp)` / `getCriticalTemp()` - Critical temperature threshold
- `setHysteresis(hyst)` / `getHysteresis()` - Temperature hysteresis (0°C, 1.5°C, 3°C, 6°C)
- `setAlertPolarity(activeHigh)` - Configure active-high or active-low output
- `setAlertMode(interruptMode)` - Choose comparator or interrupt mode
- `setAlertSelectCriticalOnly(critOnly)` - Monitor critical temp only or all boundaries
- `enableAlert(enable)` - Enable/disable alert output
- `getAlertStatus()` - Read current alert status

### Supported Use Cases
- **Comparator mode**: Auto-clearing alerts for thermostat applications (fans, cooling systems)
- **Interrupt mode**: Latching alerts for microcontroller-based event logging
- **Temperature windows**: Monitor both upper and lower boundaries
- **Critical-only**: Simple over-temperature protection

## Implementation Details

- Added temperature conversion helpers (`tempToReg()`, `regToTemp()`) for proper register formatting
- All functions validate input ranges (-40°C to +125°C)
- Hysteresis applies when temperature decreases below threshold
- Alert Select bit configures critical-only vs. window monitoring
- Compatible with existing library functions

## Testing

Tested on a custom RP2040 board with:
- Comparator mode with various hysteresis settings
- Interrupt mode with ISR handling
- Temperature crossing thresholds in both directions
- Multiple heating/cooling cycles

## Example Usage
```cpp
#include <Adafruit_MCP9808.h>

Adafruit_MCP9808 tempsensor = Adafruit_MCP9808();

void setup() {
  tempsensor.begin(0x18);
  
  // Simple critical temperature alert at 30°C
  // Active-low, comparator mode, 1.5°C hysteresis using the critical temperature only
  tempsensor.setTempAlert(30.0, false, false, MCP9808_HYST_1_5C, true);
  
  // Or configure individual settings:
  tempsensor.setCriticalTemp(30.0);
  tempsensor.setAlertPolarity(false);  // Active-low
  tempsensor.setAlertMode(false);      // Comparator mode
  tempsensor.setHysteresis(MCP9808_HYST_1_5C);
  tempsensor.setAlertSelectCriticalOnly(true);
  tempsensor.enableAlert(true);
}

void loop() {
  float temp = tempsensor.readTempC();
  bool alert = tempsensor.getAlertStatus();
  
  Serial.print("Temp: ");
  Serial.print(temp);
  Serial.print("°C | Alert: ");
  Serial.println(alert ? "ACTIVE" : "Inactive");
  
  delay(500);
}
```

## Backwards Compatibility

All existing library functions remain unchanged. This PR only adds new functionality.

## Checklist

- [x] Code compiles without warnings
- [x] Functions are documented with doxygen-style comments
- [x] Tested on hardware
- [x] Follows existing library code style

## Related Documentation

MCP9808 Datasheet sections referenced:
- Section 5.1.1: Configuration Register (Register 5-2)
- Section 5.1.2: Temperature Limit Registers (Register 5-3)
- Section 5.2.2: Temperature Hysteresis
- Section 5.2.3: Alert Output Configuration